### PR TITLE
Impl std::error::error for Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,9 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
         Error {


### PR DESCRIPTION
Closes #2 