### PR TITLE
Return error on the TODO cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flexiber"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Nicolas Stalder <n@stalder.io>", "RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -174,7 +174,8 @@ impl Encodable for Tag {
                 encoder.byte((self.number & 0x7F) as u8)
             }
             0x4000..=0xFFFF => {
-                todo!();
+                // todo()
+                return Err(Error::from(ErrorKind::UnsupportedTagSize));
             }
         }
     }
@@ -203,7 +204,8 @@ impl Decodable<'_> for Tag {
                     if third_byte & NOT_LAST_TAG_OCTET_FLAG == 0 {
                         ((number as u16) << 7) | (third_byte as u16)
                     } else {
-                        todo!();
+                        // todo()
+                        return Err(Error::from(ErrorKind::InvalidLength));
                     }
                 }
             }


### PR DESCRIPTION
Avoid crashing done by todo!() by returning error instead.

